### PR TITLE
add pipeline and package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/*
+!/out
+/out/package.json

--- a/README.md
+++ b/README.md
@@ -1,33 +1,17 @@
-# Project
+# @vscode/openssl-prebuilt
 
-> This repo has been populated by an initial template to help get you started. Please
-> make sure to update the content to build a great experience for community-building.
+This is a public package containing static compilations of OpenSSL used in the VS Code CLI, for every platform that we publish on. It's available to install via npm as:
 
-As the maintainer of this project, please make a few updates:
+```
+npm install --save @vscode/openssl-prebuilt
+```
 
-- Improving this README.MD file to provide a great experience
-- Updating SUPPORT.MD with content about this project's support experience
-- Understanding the security reporting process in SECURITY.MD
-- Remove this section from the README
-
-## Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+We use this to reduce the amount of compilation done at build time for VS Code, and we compile OpenSSL from signed sources ourselves to ensure supply chain security. This package may be pulled down automatically when building the VS Code CLI from sources, depending on your platform and configuration.
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
-trademarks or logos is subject to and must follow 
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
+trademarks or logos is subject to and must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vscode/openssl-prebuilt",
+  "version": "0.0.5",
+  "description": "Prebuilt openssl libraries for platforms VS Code is published on",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/microsoft/vscode-openssl-prebuilt.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/microsoft/vscode-openssl-prebuilt/issues"
+  },
+  "homepage": "https://github.com/microsoft/vscode-openssl-prebuilt#readme"
+}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,0 +1,44 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: main
+      endpoint: Monaco
+
+parameters:
+  - name: publishPackage
+    displayName: 🚀 Publish test-electron
+    type: boolean
+    default: false
+
+extends:
+  template: azure-pipelines/npm-package/pipeline.yml@templates
+  parameters:
+    npmPackages:
+      - name: openssl-prebuilt
+        publishPackage: ${{ parameters.publishPackage }}
+        testPlatforms: []
+        buildSteps:
+          - script: node -p "'##vso[task.setvariable variable=PKG_VERSION]' + require('./package.json').version"
+            displayName: Get version
+
+          - task: Npm@1
+            displayName: Download openssl prebuilt
+            inputs:
+              command: custom
+              customCommand: pack @vscode-internal/openssl-prebuilt@$(PKG_VERSION)
+              customRegistry: useFeed
+              customFeed: "Monaco/openssl-prebuilt"
+              workingDir: $(Build.ArtifactStagingDirectory)
+
+          - script: |
+              set -e
+              mkdir $(Build.SourcesDirectory)/out
+              tar -xvzf $(Build.ArtifactStagingDirectory)/vscode-internal-openssl-prebuilt-$(PKG_VERSION).tgz --strip-components=1 --directory=$(Build.SourcesDirectory)/out
+            displayName: Extract openssl prebuilt


### PR DESCRIPTION
This pipeline just republishes the internal openssl-prebuilt from the feed. Opted to do it this way for the moment since the npm pipeline doesn't support the advanced set of stages that we use for cross-compiling everything in the internal build.

We plan to use this as a public package that can be pulled down to aid in compiling the VS Code CLI on developers machines. Namely on Windows where a default OpenSSL installation is rare.